### PR TITLE
more accurate response message

### DIFF
--- a/src/Message/PayeezyResponse.php
+++ b/src/Message/PayeezyResponse.php
@@ -120,7 +120,13 @@ class PayeezyResponse extends AbstractResponse
 
     public function getMessage()
     {
-        return $this->getDataItem('exact_message');
+        // bank_message is more human readable. See: https://support.payeezy.com/hc/en-us/articles/206601408-First-Data-Payeezy-Gateway-Web-Service-API-Reference-Guide
+        $message = $this->getDataItem('bank_message');
+        if (empty($message)) {
+            $message = $this->getDataItem('exact_message');
+        }
+
+        return $message;
     }
 
     /**


### PR DESCRIPTION
`exact_message` returns “Transaction Normal” when `transaction_approved` is 0 (failure).

This provides a more descriptive message if available.